### PR TITLE
Fix 2 bugs in `validateCertUri`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var validator = require('validator');
 var TIMESTAMP_TOLERANCE = 150;
 var VALID_CERT_HOSTNAME = 's3.amazonaws.com';
 var VALID_CERT_PATH_START = '/echo.api/';
-var VALID_CERT_PORT = 443;
+var VALID_CERT_PORT = '443';
 var SIGNATURE_FORMAT = 'base64';
 
 
@@ -96,8 +96,8 @@ function validateCertUri(cert_uri) {
   if (cert_uri.port && (cert_uri.port !== VALID_CERT_PORT)) {
     return "Certificate URI port MUST be " + VALID_CERT_PORT + ", was: " + cert_uri.port;
   }
-  if (cert_uri.host !== VALID_CERT_HOSTNAME) {
-    return "Certificate URI hostname must be " + VALID_CERT_HOSTNAME + ": " + cert_uri;
+  if (cert_uri.hostname !== VALID_CERT_HOSTNAME) {
+    return "Certificate URI hostname must be " + VALID_CERT_HOSTNAME + ": " + cert_uri.hostname;
   }
   if (cert_uri.path.indexOf(VALID_CERT_PATH_START) !== 0) {
     return "Certificate URI path must start with " + VALID_CERT_PATH_START + ": " + cert_uri;
@@ -141,7 +141,7 @@ function validateTimestamp(requestBody) {
 
 
 // certificate validator express middleware for amazon echo
-module.exports = function(cert_url, signature, requestBody, callback) {
+var verifier = module.exports = function(cert_url, signature, requestBody, callback) {
   var er;
   if (cert_url == null) {
     cert_url = '';
@@ -176,3 +176,6 @@ module.exports = function(cert_url, signature, requestBody, callback) {
     callback();
   });
 };
+
+// Export to make unit testing easier:
+verifier.validateCertUri = validateCertUri;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "validator": "^5.3.0"
   },
   "devDependencies": {
-    "tap": "^6.1.1"
+    "tap": "^6.1.1",
+    "unroll": "^1.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,39 @@
 var test     = require('tap').test;
+var unroll   = require('unroll');
+unroll.use(test);
+
+var url      = require('url');
 var verifier = require('../');
+
+unroll('verifier.validateCertUri should be #valid for #url',
+  function(t, testArgs) {
+    let cert_uri = url.parse(testArgs['url']);
+    let result = verifier.validateCertUri(cert_uri);
+    let valid = testArgs['valid'];
+    t.notEqual(valid, undefined);
+    if (valid === true) {
+      t.equal(result, true);
+    } else {
+      // I don't care too much about the error message, so do negated
+      // comparison with 'true':
+      t.notEqual(result, true);
+    }
+    t.end();
+  },
+  [
+    ['valid', 'url'],
+    [true, 'https://s3.amazonaws.com/echo.api/echo-api-cert.pem'],
+    [true, 'HTTPS://s3.amazonaws.com/echo.api/echo-api-cert.pem'],
+    [true, 'https://S3.AMAZONAWS.COM/echo.api/echo-api-cert.pem'],
+    [true, 'https://s3.amazonaws.com:443/echo.api/echo-api-cert.pem'],
+    [true, 'https://s3.amazonaws.com/echo.api/../echo.api/echo-api-cert.pem'],
+    [false, 'http://s3.amazonaws.com/echo.api/echo-api-cert.pem'],  // (invalid protocol)
+    [false, 'https://notamazon.com/echo.api/echo-api-cert.pem'],  // (invalid hostname)
+    [false, 'https://s3.amazonaws.com/EcHo.aPi/echo-api-cert.pem'],  // (invalid path)
+    [false, 'https://s3.amazonaws.com/invalid.path/echo-api-cert.pem'],  // (invalid path)
+    [false, 'https://s3.amazonaws.com:563/echo.api/echo-api-cert.pem']  // (invalid port)
+  ]
+);
 
 
 test('handle invalid cert_url parameter', function(t) {


### PR DESCRIPTION
- url.port is a String, while it was being compared to a Number using `!==`
- url.host includes the port, use url.hostname instead
- beef up the unit tests to cover all the cases, using Amazon's test cases from https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/developing-an-alexa-skill-as-a-web-service#Verifying%20that%20the%20Request%20was%20Sent%20by%20Alexa