### PR TITLE
Check "Not before" date

### DIFF
--- a/test/validate-cert.js
+++ b/test/validate-cert.js
@@ -111,7 +111,7 @@ test('fails on non amazon subject common name', function(t) {
 test('fails on expired certificate (Not After)', function(t) {
   getEchoCert(oldCertUrl, function(err, pem) {
     var er = validateCert(pem)
-    t.assert(er === 'certificate Not After check failed', 'Certificate is expired (Not After)')
+    t.assert(er === 'invalid Not After date (date already passed)', 'Certificate is expired (Not After)')
     t.end()
   })
 })

--- a/test/validate-cert.js
+++ b/test/validate-cert.js
@@ -108,10 +108,10 @@ test('fails on non amazon subject common name', function(t) {
   t.end()
 })
 
-test('fails on expired certificate', function(t) {
+test('fails on expired certificate (Not After)', function(t) {
   getEchoCert(oldCertUrl, function(err, pem) {
     var er = validateCert(pem)
-    t.assert(er === 'certificate expiration check failed', 'Certificate is expired')
+    t.assert(er === 'certificate Not After check failed', 'Certificate is expired (Not After)')
     t.end()
   })
 })

--- a/validate-cert.js
+++ b/validate-cert.js
@@ -16,13 +16,13 @@ module.exports = function validate(pem_cert) {
     var currTime = new Date().getTime()
     var notAfterTime = new Date(cert.validity.notAfter).getTime()
     if (notAfterTime <= currTime) {
-      return 'certificate Not After check failed'
+      return 'invalid Not After date (date already passed)'
     }
 
     // ensure that current time is later than cert's "Not Before" time
     var notBeforeTime = new Date(cert.validity.notBefore).getTime()
     if (currTime <= notBeforeTime) {
-      return 'certificate Not Before check failed'
+      return 'invalid Not Before date (date has not occured)'
     }
   } catch (e) {
     return e

--- a/validate-cert.js
+++ b/validate-cert.js
@@ -12,18 +12,16 @@ module.exports = function validate(pem_cert) {
       return 'subjectAltName Check Failed'
     }
 
-    // check that the signing certificate has not expired (examine Not After)
-    var now = new Date().getTime()
-    var notAfter = new Date(cert.validity.notAfter)
-    var timeUntilAfter = notAfter.getTime() - now
-    if (timeUntilAfter < 1) {
+    // ensure that current time is earlier than cert's "Not After" time
+    var currTime = new Date().getTime()
+    var notAfterTime = new Date(cert.validity.notAfter).getTime()
+    if (notAfterTime <= currTime) {
       return 'certificate Not After check failed'
     }
 
-    // check that the signing certificate has not expired (examine Not Before)
-    var notBefore = new Date(cert.validity.notBefore)
-    var timeSinceBefore = now - notBefore.getTime()
-    if (timeSinceBefore < 1) {
+    // ensure that current time is later than cert's "Not Before" time
+    var notBeforeTime = new Date(cert.validity.notBefore).getTime()
+    if (currTime <= notBeforeTime) {
       return 'certificate Not Before check failed'
     }
   } catch (e) {

--- a/validate-cert.js
+++ b/validate-cert.js
@@ -12,12 +12,19 @@ module.exports = function validate(pem_cert) {
       return 'subjectAltName Check Failed'
     }
 
+    // check that the signing certificate has not expired (examine Not After)
+    var now = new Date().getTime()
     var notAfter = new Date(cert.validity.notAfter)
-    var remainingDays = notAfter.getTime() - new Date().getTime()
-    // check that the signing certificate has not expired (examine both the Not
-    // Before and Not After dates)
-    if (remainingDays < 1) {
-      return 'certificate expiration check failed'
+    var timeUntilAfter = notAfter.getTime() - now
+    if (timeUntilAfter < 1) {
+      return 'certificate Not After check failed'
+    }
+
+    // check that the signing certificate has not expired (examine Not Before)
+    var notBefore = new Date(cert.validity.notBefore)
+    var timeSinceBefore = now - notBefore.getTime()
+    if (timeSinceBefore < 1) {
+      return 'certificate Not Before check failed'
     }
   } catch (e) {
     return e


### PR DESCRIPTION
Fixes issue #23 

Main changes:

- Added check for `Not Before` date in certificate
- Modified existing `Not After` test to adopt new error message

I haven't added a test for this `Not Before` check yet. It looks like the `Not After` test uses an old certificate, which makes sense. Unfortunately we can't use a future certificate for a `Not Before` test :) I guess we have to build out a fake certificate. Ideas welcome.