### PR TITLE
update node-forge to fix Veracode SCA vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Mike Reinstein",
   "license": "MIT",
   "dependencies": {
-    "node-forge": "^0.10.0",
+    "node-forge": "^1.2.1",
     "validator": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Veracode SCA reports:
https://sca.analysiscenter.veracode.com/vulnerability-database/security/sca/vulnerability/sid-33572/summary
https://sca.analysiscenter.veracode.com/vulnerability-database/security/sca/vulnerability/sid-33569/summary
https://nvd.nist.gov/vuln/detail/CVE-2022-0122

for node-forge upto v0.10.0 including